### PR TITLE
Add support for special characters in file name

### DIFF
--- a/index.php
+++ b/index.php
@@ -174,7 +174,7 @@ function display_block( $file )
 	global $ignore_file_list, $ignore_ext_list, $force_download;
 	
 	$file_ext = ext($file);
-	if( !$file_ext AND is_dir($file)) $file_ext = "dir";
+	if(is_dir($file)) $file_ext = "dir";
 	if(in_array($file, $ignore_file_list)) return;
 	if(in_array($file_ext, $ignore_ext_list)) return;
 	

--- a/index.php
+++ b/index.php
@@ -179,8 +179,10 @@ function display_block( $file )
 	if(in_array($file_ext, $ignore_ext_list)) return;
 	
 	$download_att = ($force_download AND $file_ext != "dir" ) ? " download=\"" . htmlEntities(basename($file), ENT_QUOTES) . "\"" : "";
+	$file_url = htmlEntities(rawurlencode($file), ENT_QUOTES);
+
 	$rtn = "<div class=\"block\">";
-	$rtn .= "<a href=\"$file\" class=\"$file_ext\"{$download_att}>";
+	$rtn .= "<a href=\"$file_url\" class=\"$file_ext\"{$download_att}>";
 	$rtn .= "	<div class=\"img $file_ext\"></div>";
 	$rtn .= "	<div class=\"name\">";
 	

--- a/index.php
+++ b/index.php
@@ -178,8 +178,7 @@ function display_block( $file )
 	if(in_array($file, $ignore_file_list)) return;
 	if(in_array($file_ext, $ignore_ext_list)) return;
 	
-	$download_att = ($force_download AND $file_ext != "dir" ) ? " download='" . basename($file) . "'" : "";
-	
+	$download_att = ($force_download AND $file_ext != "dir" ) ? " download=\"" . htmlEntities(basename($file), ENT_QUOTES) . "\"" : "";
 	$rtn = "<div class=\"block\">";
 	$rtn .= "<a href=\"$file\" class=\"$file_ext\"{$download_att}>";
 	$rtn .= "	<div class=\"img $file_ext\"></div>";

--- a/index.php
+++ b/index.php
@@ -187,13 +187,13 @@ function display_block( $file )
 	
 	if ($file_ext === "dir") 
 	{
-		$rtn .= "		<div class=\"file fs-1-2 bold\">" . basename($file) . "</div>";
+		$rtn .= "		<div class=\"file fs-1-2 bold\">" . htmlspecialchars(basename($file), ENT_QUOTES) . "</div>";
 		$rtn .= "		<div class=\"data upper size fs-0-7\"><span class=\"bold\">" . count_dir_files($file) . "</span> files</div>";
 		$rtn .= "		<div class=\"data upper size fs-0-7\"><span class=\"bold\">Size:</span> " . get_directory_size($file) . "</div>";
 	}
 	else
 	{
-		$rtn .= "		<div class=\"file fs-1-2 bold\">" . basename($file) . "</div>";
+		$rtn .= "		<div class=\"file fs-1-2 bold\">" . htmlspecialchars(basename($file), ENT_QUOTES) . "</div>";
 		$rtn .= "		<div class=\"data upper size fs-0-7\"><span class=\"bold\">Size:</span> " . display_size(filesize($file)) . "</div>";
 		$rtn .= "		<div class=\"data upper modified fs-0-7\"><span class=\"bold\">Last modified:</span> " .  date("D. F jS, Y - h:ia", filemtime($file)) . "</div>";	
 	}

--- a/index.php
+++ b/index.php
@@ -139,10 +139,10 @@ function ext($filename)
 function display_size($bytes, $precision = 2) 
 {
 	$units = array('B', 'KB', 'MB', 'GB', 'TB');
-    $bytes = max($bytes, 0); 
-    $pow = floor(($bytes ? log($bytes) : 0) / log(1024)); 
-    $pow = min($pow, count($units) - 1); 
-    $bytes /= (1 << (10 * $pow)); 
+	$bytes = max($bytes, 0); 
+	$pow = floor(($bytes ? log($bytes) : 0) / log(1024)); 
+	$pow = min($pow, count($units) - 1); 
+	$bytes /= (1 << (10 * $pow)); 
 	return round($bytes, $precision) . '<span class="fs-0-8 bold">' . $units[$pow] . "</span>";
 }
 
@@ -154,17 +154,17 @@ function count_dir_files( $dir)
 
 function get_directory_size($path)
 {
-    $bytestotal = 0;
-    $path = realpath($path);
-    if($path!==false && $path!='' && file_exists($path))
-    {
-        foreach(new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS)) as $object)
-        {
-            $bytestotal += $object->getSize();
-        }
-    }
-    
-    return display_size($bytestotal);
+	$bytestotal = 0;
+	$path = realpath($path);
+	if($path!==false && $path!='' && file_exists($path))
+	{
+		foreach(new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path, FilesystemIterator::SKIP_DOTS)) as $object)
+		{
+			$bytestotal += $object->getSize();
+		}
+	}
+	
+	return display_size($bytestotal);
 }
 
 
@@ -190,7 +190,6 @@ function display_block( $file )
 		$rtn .= "		<div class=\"file fs-1-2 bold\">" . basename($file) . "</div>";
 		$rtn .= "		<div class=\"data upper size fs-0-7\"><span class=\"bold\">" . count_dir_files($file) . "</span> files</div>";
 		$rtn .= "		<div class=\"data upper size fs-0-7\"><span class=\"bold\">Size:</span> " . get_directory_size($file) . "</div>";
-		
 	}
 	else
 	{

--- a/index.php
+++ b/index.php
@@ -181,27 +181,27 @@ function display_block( $file )
 	$download_att = ($force_download AND $file_ext != "dir" ) ? " download=\"" . htmlEntities(basename($file), ENT_QUOTES) . "\"" : "";
 	$file_url = htmlEntities(rawurlencode($file), ENT_QUOTES);
 
-	$rtn = "<div class=\"block\">";
-	$rtn .= "<a href=\"$file_url\" class=\"$file_ext\"{$download_att}>";
-	$rtn .= "	<div class=\"img $file_ext\"></div>";
-	$rtn .= "	<div class=\"name\">";
+	$rtn = "<div class=\"block\">".PHP_EOL;
+	$rtn .= "<a href=\"$file_url\" class=\"$file_ext\"{$download_att}>".PHP_EOL;
+	$rtn .= "	<div class=\"img $file_ext\"></div>".PHP_EOL;
+	$rtn .= "	<div class=\"name\">".PHP_EOL;
 	
 	if ($file_ext === "dir") 
 	{
-		$rtn .= "		<div class=\"file fs-1-2 bold\">" . htmlspecialchars(basename($file), ENT_QUOTES) . "</div>";
-		$rtn .= "		<div class=\"data upper size fs-0-7\"><span class=\"bold\">" . count_dir_files($file) . "</span> files</div>";
-		$rtn .= "		<div class=\"data upper size fs-0-7\"><span class=\"bold\">Size:</span> " . get_directory_size($file) . "</div>";
+		$rtn .= "		<div class=\"file fs-1-2 bold\">" . htmlspecialchars(basename($file), ENT_QUOTES) . "</div>".PHP_EOL;
+		$rtn .= "		<div class=\"data upper size fs-0-7\"><span class=\"bold\">" . count_dir_files($file) . "</span> files</div>".PHP_EOL;
+		$rtn .= "		<div class=\"data upper size fs-0-7\"><span class=\"bold\">Size:</span> " . get_directory_size($file) . "</div>".PHP_EOL;
 	}
 	else
 	{
-		$rtn .= "		<div class=\"file fs-1-2 bold\">" . htmlspecialchars(basename($file), ENT_QUOTES) . "</div>";
-		$rtn .= "		<div class=\"data upper size fs-0-7\"><span class=\"bold\">Size:</span> " . display_size(filesize($file)) . "</div>";
-		$rtn .= "		<div class=\"data upper modified fs-0-7\"><span class=\"bold\">Last modified:</span> " .  date("D. F jS, Y - h:ia", filemtime($file)) . "</div>";	
+		$rtn .= "		<div class=\"file fs-1-2 bold\">" . htmlspecialchars(basename($file), ENT_QUOTES) . "</div>".PHP_EOL;
+		$rtn .= "		<div class=\"data upper size fs-0-7\"><span class=\"bold\">Size:</span> " . display_size(filesize($file)) . "</div>".PHP_EOL;
+		$rtn .= "		<div class=\"data upper modified fs-0-7\"><span class=\"bold\">Last modified:</span> " .  date("D. F jS, Y - h:ia", filemtime($file)) . "</div>".PHP_EOL;	
 	}
 
-	$rtn .= "	</div>";
-	$rtn .= "	</a>";
-	$rtn .= "</div>";
+	$rtn .= "	</div>".PHP_EOL;
+	$rtn .= "	</a>".PHP_EOL;
+	$rtn .= "</div>".PHP_EOL;
 	return $rtn;
 }
 


### PR DESCRIPTION
Examples what this PR fixes:
- File name containing `'` would result to cropped downloaded name, fixed in 6f26be97d9a1bb38af0ae9f41c64e008bc459ebc.
- File name containing `#` would not be downloaded, because its url was not url encoded, fixed in 6a3e40b178836f6c353e74a3b0c07d89331e85e5.
- File name containing any HTML tag would be rendered, e.g. `<b>File</b>` or `<script>alert('evil');</script>`, fixed in a99a51a80c411e0ced0d917e32ada7332989fa35.

Other changes:
- Unified tabs whitespaces in f1f3099a13eac15391ab2715650323cbade94f50.
- Added missing `PHP_EOL` in 589a6c4ed2ab2fc83df44e8e641acdac1be774c2.
- Fixed issues #33 and #16 in 95f6bf17033bf01dc27ef69b7d159b80b334fea0.